### PR TITLE
Add 8 channel ws2812 addressable led library

### DIFF
--- a/rp2040_pio_dma.py
+++ b/rp2040_pio_dma.py
@@ -1,3 +1,4 @@
+import rp2040_device
 from machine import Pin
 from rp2 import PIO, StateMachine, asm_pio
 from time import sleep
@@ -76,17 +77,11 @@ DREQ_UART0_RX, DREQ_UART1_TX, DREQ_UART1_RX = 21, 22, 23
 DREQ_I2C0_TX,  DREQ_I2C0_RX,  DREQ_I2C1_TX  = 32, 33, 34
 DREQ_I2C1_RX,  DREQ_ADC                     = 35, 36
 
+
+
 DMA_CHANS = [struct(DMA_BASE + n*DMA_CHAN_WIDTH, DMA_CHAN_REGS) for n in range(0,DMA_CHAN_COUNT)]
 DMA_DEVICE = struct(DMA_BASE, DMA_REGS)
 
-PIO0_TX0 = PIO0_BASE + 0x010
-PIO0_TX1 = PIO0_BASE + 0x014
-PIO0_TX2 = PIO0_BASE + 0x018
-PIO0_TX3 = PIO0_BASE + 0x01c
-PIO1_TX0 = PIO1_BASE + 0x010
-PIO0_TX1 = PIO1_BASE + 0x014
-PIO0_TX2 = PIO1_BASE + 0x018
-PIO0_TX3 = PIO1_BASE + 0x01c
 
 GPIO_FUNC_SPI, GPIO_FUNC_UART, GPIO_FUNC_I2C = 1, 2, 3
 GPIO_FUNC_PWM, GPIO_FUNC_SIO, GPIO_FUNC_PIO0 = 4, 5, 6
@@ -100,30 +95,12 @@ class PIO_DMA_Transfer():
         self.dma_chan = DMA_CHANS[dma_channel]
         self.channel_number = dma_channel
        
-        if (sm_num == 0):
-            self.dma_chan.WRITE_ADDR_REG = PIO0_TX0
-            self.dma_chan.CTRL_TRIG.TREQ_SEL = DREQ_PIO0_TX0
-        elif (sm_num == 1):
-            self.dma_chan.WRITE_ADDR_REG = PIO0_TX1
-            self.dma_chan.CTRL_TRIG.TREQ_SEL = DREQ_PIO0_TX1
-        elif (sm_num == 2):
-            self.dma_chan.WRITE_ADDR_REG = PIO0_TX2
-            self.dma_chan.CTRL_TRIG.TREQ_SEL = DREQ_PIO0_TX2
-        elif (sm_num == 3):
-            self.dma_chan.WRITE_ADDR_REG = PIO0_TX3
-            self.dma_chan.CTRL_TRIG.TREQ_SEL = DREQ_PIO0_TX3
-        elif (sm_num == 4):
-            self.dma_chan.WRITE_ADDR_REG = PIO1_TX0
-            self.dma_chan.CTRL_TRIG.TREQ_SEL = DREQ_PIO1_TX0
-        elif (sm_num == 5):
-            self.dma_chan.WRITE_ADDR_REG = PIO1_TX1
-            self.dma_chan.CTRL_TRIG.TREQ_SEL = DREQ_PIO1_TX1
-        elif (sm_num == 6):
-            self.dma_chan.WRITE_ADDR_REG = PIO1_TX2
-            self.dma_chan.CTRL_TRIG.TREQ_SEL = DREQ_PIO1_TX2
-        elif (sm_num == 7):
-            self.dma_chan.WRITE_ADDR_REG = PIO1_TX3
-            self.dma_chan.CTRL_TRIG.TREQ_SEL = DREQ_PIO1_TX3
+        if (sm_num >= 0 and sm_num < 4):
+            self.dma_chan.WRITE_ADDR_REG = PIO0_BASE + 0x10 + sm_num *4
+            self.dma_chan.CTRL_TRIG.TREQ_SEL = sm_num
+        elif (sm_num < 8):
+            self.dma_chan.WRITE_ADDR_REG = PIO1_BASE + 0x10 + (sm_num-4) *4
+            self.dma_chan.CTRL_TRIG.TREQ_SEL = sm_num + 4
         
         if (block_size == 8):
             self.dma_chan.CTRL_TRIG.DATA_SIZE = DMA_SIZE_BYTE
@@ -213,3 +190,4 @@ class DMA_Control_Block:
             return True
         else:
             return False
+

--- a/rp2040_pio_dma.py
+++ b/rp2040_pio_dma.py
@@ -1,4 +1,3 @@
-import rp2040_device
 from machine import Pin
 from rp2 import PIO, StateMachine, asm_pio
 from time import sleep

--- a/ws2812.py_pio_dma
+++ b/ws2812.py_pio_dma
@@ -1,0 +1,105 @@
+# Example using PIO to drive a set of WS2812 LEDs.
+import array
+from machine import Pin
+import dma
+import uasyncio as asyncio
+
+# Configure the number of WS2812 LEDs.
+NUM_LEDS = 256
+PIN_NUM = 0
+brightness = 0.2
+
+@rp2.asm_pio(sideset_init=rp2.PIO.OUT_LOW, out_shiftdir=rp2.PIO.SHIFT_RIGHT, autopull=True, pull_thresh=24)
+def ws2812():
+    T1 = 2
+    T2 = 5
+    T3 = 3
+    wrap_target()
+    label("bitloop")
+    out(x, 1)               .side(0)    [T3 - 1]
+    jmp(not_x, "do_zero")   .side(1)    [T1 - 1]
+    jmp("bitloop")          .side(1)    [T2 - 1]
+    label("do_zero")
+    nop()                   .side(0)    [T2 - 1]
+    wrap()
+
+class WS2812B: 
+    def __init__(self, num_leds=8, pin_num=0, state_machine=0, brightness=1):
+        # Create the StateMachine with the ws2812 program, outputting on pin
+        self.sm = rp2.StateMachine(state_machine, ws2812, freq=8_000_000, sideset_base=Pin(pin_num))
+
+        # Start the StateMachine, it will wait for data on its FIFO.
+        self.sm.active(1)
+
+        # Display a pattern on the LEDs via an array of LED RGB values.
+        self.ar = array.array("I", [0 for _ in range(num_leds)])
+        self.num_leds = num_leds
+        self.brightness = brightness
+        self.pio_dma = dma.PIO_DMA_Transfer(state_machine+4, state_machine, 32, num_leds)
+
+  def show(self):
+        #self.sm.put(self.ar)
+        self.pio_dma.start_transfer(self.ar)
+        
+    def set(self, i, color):
+        self.ar[i] = int((color[1]<<16)*self.brightness) + int((color[0]<<8)*self.brightness) + int(color[2]*self.brightness)
+
+    def fill(self, color):
+        for i in range(len(self.ar)):
+            self.set(i, color)
+
+    def wait(self):
+        return self.pio_dma.busy()
+    
+    async def color_chase(self, color, wait):
+        for i in range(self.num_leds):
+            self.set(i, color)
+            time.sleep(wait)
+            self.show()
+        await asyncio.sleep(0.2)
+     
+    def wheel(self, pos):
+        # Input a value 0 to 255 to get a color value.
+        # The colours are a transition r - g - b - back to r.
+        if pos < 0 or pos > 255:
+            return (0, 0, 0)
+        if pos < 85:
+            return (255 - pos * 3, pos * 3, 0)
+        if pos < 170:
+            pos -= 85
+            return (0, 255 - pos * 3, pos * 3)
+        pos -= 170
+        return (pos * 3, 0, 255 - pos * 3)
+      
+    async def rainbow_cycle(self, wait):
+        for j in range(255):
+            for i in range(self.num_leds):
+                rc_index = (i * 256 // self.num_leds) + j
+                self.set(i, self.wheel(rc_index & 255))
+            self.show()
+            await asyncio.sleep(wait)
+
+    BLACK = (0, 0, 0)
+    RED = (255, 0, 0)
+    YELLOW = (255, 150, 0)
+    GREEN = (0, 255, 0)
+    CYAN = (0, 255, 255)
+    BLUE = (0, 0, 255)
+    PURPLE = (180, 0, 255)
+    WHITE = (255, 255, 255)
+    COLORS = (BLACK, RED, YELLOW, GREEN, CYAN, BLUE, PURPLE, WHITE)
+
+async def fill(num_leds, pin_num, wait=1):
+    ws = WS2812B(num_leds=num_leds, pin_num=pin_num, state_machine=pin_num, brightness=1)
+    while True:
+        for color in ws.COLORS:            
+            ws.fill(color)
+            ws.show()
+            await asyncio.sleep(wait)
+            
+if __name__ == "__main__":
+    loop = asyncio.get_event_loop()
+    asyncio.create_task(fill(8, 0, 2))
+    asyncio.create_task(fill(8, 1, 1))
+    loop.run_forever()
+


### PR DESCRIPTION
Here is a library for ws2812 addressable leds that uses rp2040_pio_dm.
It can drive 8 separate led strips using 8 pio and 8 dma channels. 
Has a built in example using asyncio for delays.

rp2040_pio_dm.py was missing address defines for most of the dma CTRL_TRIG.TREQ_SEL. Instead of defining them I have computed them as well as WRITE_ADDR_REG. These can be changed to defines if wanted.